### PR TITLE
feat: enforce campus geographic boundaries on map view

### DIFF
--- a/mobile/src/components/LocationScreen/GoogleMaps.tsx
+++ b/mobile/src/components/LocationScreen/GoogleMaps.tsx
@@ -16,7 +16,7 @@ export default function GoogleMaps() {
     if (mapRef.current && Platform.OS === "android") {
       mapRef.current.setMapBoundaries(
         campusBoundary.northEast,
-        campusBoundary.southWest
+        campusBoundary.southWest,
       );
     }
   };

--- a/mobile/src/constants/campusBoundaries.ts
+++ b/mobile/src/constants/campusBoundaries.ts
@@ -10,7 +10,7 @@ type CampusBoundary = {
 
 const campusBoundary: CampusBoundary = {
   northEast: { latitude: 45.5049, longitude: -73.5612 },
-  southWest: { latitude: 45.4510, longitude: -73.6530 },
+  southWest: { latitude: 45.451, longitude: -73.653 },
 };
 
 export { campusBoundary, CampusBoundary, Coordinate };


### PR DESCRIPTION
### Summary
Implements geographic boundary enforcement to restrict users from navigating outside the defined area.
### Platform Implementation
**Android**
Uses Google Maps' native setMapBoundaries method - simply set the coordinates and the map automatically restricts user movement.
**iOS**
Custom enforcement required since Apple Maps lacks native boundary support. Each time the map center changes, a function checks if the user is within the allowed area. If not, the view scrolls back to the boundary.
### Restrictions
Panning beyond rectangular campus boundary
Zooming out to view areas outside allowed region
### Boundary Configuration
The restricted area is defined as a rectangle using two coordinates:
Northeast corner (top-right)
Southwest corner (bottom-left)

These coordinates are stored in src/constants/campusBoundaries.ts and can be easily adjusted if the boundary needs to be expanded or reduced.