### PR TITLE
Fix: fixed logged error for navbar-test

### DIFF
--- a/mobile/__tests__/NavBar-test.tsx
+++ b/mobile/__tests__/NavBar-test.tsx
@@ -8,6 +8,12 @@ jest.mock("@expo/vector-icons", () => ({
   Ionicons: "",
 }));
 
+jest.mock("../src/services/BuildingDataService", () => ({
+  BuildingDataService: {
+    fetchBuildings: jest.fn().mockResolvedValue([]),
+  },
+}));
+
 jest.useFakeTimers();
 
 test("Initial screen is Home", () => {

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -2299,9 +2299,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"


### PR DESCRIPTION
Fixed logged error for navbar-test by mocking the fetchBuildings call to the backend. 
Ran `npm audit fix` to fix a vulnerability.