### PR TITLE
Fix: building markers not visible on android

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -13,14 +13,14 @@
         "@react-navigation/bottom-tabs": "^7.10.1",
         "@react-navigation/native": "^7.1.28",
         "expo": "~54.0.31",
-        "expo-location": "~18.0.4",
+        "expo-location": "~19.0.8",
         "expo-status-bar": "~3.0.9",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
         "react-native-maps": "1.20.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
-        "react-native-svg": "^15.15.1",
+        "react-native-svg": "15.12.1",
         "react-native-web": "^0.21.0"
       },
       "devDependencies": {
@@ -7386,9 +7386,9 @@
       }
     },
     "node_modules/expo-location": {
-      "version": "18.0.10",
-      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-18.0.10.tgz",
-      "integrity": "sha512-R0Iioz0UZ9Ts8TACPngh8uDFbajJhVa5/igLqWB8Pq/gp8UHuwj7PC8XbZV7avsFoShYjaxrOhf4U7IONeKLgg==",
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-19.0.8.tgz",
+      "integrity": "sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
@@ -12435,9 +12435,9 @@
       }
     },
     "node_modules/react-native-svg": {
-      "version": "15.15.1",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.1.tgz",
-      "integrity": "sha512-ZUD1xwc3Hwo4cOmOLumjJVoc7lEf9oQFlHnLmgccLC19fNm6LVEdtB+Cnip6gEi0PG3wfvVzskViEtrySQP8Fw==",
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
+      "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
       "license": "MIT",
       "dependencies": {
         "css-select": "^5.1.0",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -33,14 +33,14 @@
     "@react-navigation/bottom-tabs": "^7.10.1",
     "@react-navigation/native": "^7.1.28",
     "expo": "~54.0.31",
-    "expo-location": "~18.0.4",
+    "expo-location": "~19.0.8",
     "expo-status-bar": "~3.0.9",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-maps": "1.20.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-svg": "^15.15.1",
+    "react-native-svg": "15.12.1",
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {

--- a/mobile/src/components/LocationScreen/BuildingMarker.tsx
+++ b/mobile/src/components/LocationScreen/BuildingMarker.tsx
@@ -59,7 +59,6 @@ export default function BuildingMarker({
       title={building.buildingCode}
       description={building.buildingName}
       anchor={{ x: 0.5, y: 1 }}
-      tracksViewChanges={false}
     >
       <CustomMarker isHighlighted={isCurrentBuilding} />
     </Marker>


### PR DESCRIPTION
This pull request removes an unnecessary prop from the `BuildingMarker` component. It fixes the issue where building markers are not visible on android

Fix

* Removed the `tracksViewChanges={false}` prop from the `Marker` component in `BuildingMarker.tsx`,  to resolve the bug.

Dependency updates:

* Upgraded `expo-location` from version `~18.0.4` to `~19.0.8` in both `package.json` and `package-lock.json`,to address compatibility issue.
* Downgraded and pinned `react-native-svg` from `^15.15.1` to `15.12.1` in both `package.json` and `package-lock.json`, to address compatibility issue.