### PR TITLE
addressed building icons being cropped

### DIFF
--- a/mobile/__tests__/components/BaseMarkerIcon-test.tsx
+++ b/mobile/__tests__/components/BaseMarkerIcon-test.tsx
@@ -47,4 +47,23 @@ describe("BaseMarkerIcon", () => {
     );
     expect(screen.getByTestId("child-icon")).toBeTruthy();
   });
+
+  it("marker frame has constant dimensions regardless of scale", () => {
+    const { rerender } = render(<BaseMarkerIcon color="#ff0000" scale={1} />);
+    const frameAtScale1 = screen.getByTestId("marker-frame").props.style;
+
+    rerender(<BaseMarkerIcon color="#ff0000" scale={1.3} />);
+    const frameAtScale13 = screen.getByTestId("marker-frame").props.style;
+
+    expect(frameAtScale1.width).toBe(frameAtScale13.width);
+    expect(frameAtScale1.height).toBe(frameAtScale13.height);
+  });
+
+  it("marker frame is sized at the maximum scale", () => {
+    render(<BaseMarkerIcon color="#ff0000" scale={1} />);
+    const frame = screen.getByTestId("marker-frame").props.style;
+    // Frame is always 52x52 (40 * MAX_SCALE 1.3) so Android never clips on selection
+    expect(frame.width).toBe(52);
+    expect(frame.height).toBe(52);
+  });
 });

--- a/mobile/src/components/LocationScreen/BaseMarkerIcon.tsx
+++ b/mobile/src/components/LocationScreen/BaseMarkerIcon.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { View } from "react-native";
 import Svg, { Circle } from "react-native-svg";
 import { COLORS, MAP_CONFIG } from "../../constants";
 
@@ -11,11 +12,18 @@ interface BaseMarkerIconProps {
   readonly children?: React.ReactNode;
 }
 
+/** Maximum scale applied to a marker (selected state). */
+const MAX_SCALE = 1.3;
+
 /**
  * Shared pure-SVG marker icon used by both BuildingMarker and PoiMarker.
  *
  * Renders the three-circle base (drop-shadow, white stroke ring, coloured fill)
  * and passes through any SVG children (icon paths) to be drawn on top.
+ *
+ * The outer View is always sized at MAX_SCALE so the Android native marker
+ * frame is allocated once and never clips the icon when scale increases on
+ * selection.
  */
 export default function BaseMarkerIcon({
   color,
@@ -23,14 +31,25 @@ export default function BaseMarkerIcon({
   children,
 }: BaseMarkerIconProps) {
   const { width, height } = MAP_CONFIG.markerSize;
-  const size = { width: width * scale, height: height * scale };
+  const frameSize = { width: width * MAX_SCALE, height: height * MAX_SCALE };
+  const svgSize = { width: width * scale, height: height * scale };
 
   return (
-    <Svg width={size.width} height={size.height} viewBox="0 0 40 40">
-      <Circle cx="20" cy="20" r="14" fill={COLORS.shadowBlack} />
-      <Circle cx="20" cy="16" r="14" stroke={COLORS.white} strokeWidth="4" />
-      <Circle cx="20" cy="16" r="12" fill={color} />
-      {children}
-    </Svg>
+    <View
+      testID="marker-frame"
+      style={{
+        width: frameSize.width,
+        height: frameSize.height,
+        alignItems: "center",
+        justifyContent: "flex-end",
+      }}
+    >
+      <Svg width={svgSize.width} height={svgSize.height} viewBox="0 0 40 40">
+        <Circle cx="20" cy="20" r="14" fill={COLORS.shadowBlack} />
+        <Circle cx="20" cy="16" r="14" stroke={COLORS.white} strokeWidth="4" />
+        <Circle cx="20" cy="16" r="12" fill={color} />
+        {children}
+      </Svg>
+    </View>
   );
 }


### PR DESCRIPTION
This pull request updates the `BaseMarkerIcon` component to ensure consistent sizing and prevent clipping issues, particularly on Android, by always allocating the marker's frame at the maximum scale. It also adds new tests to verify these behaviors.

**BaseMarkerIcon sizing improvements:**

* The `BaseMarkerIcon` component now wraps its SVG in a `View` that is always sized to the maximum marker scale (`MAX_SCALE`), ensuring the marker frame never clips when the icon is scaled up (e.g., when selected). The SVG itself is scaled as before, but the outer frame remains constant. [[1]](diffhunk://#diff-579d24752eacacc988aed2e3ad800b5a1168c54143e375216adad6e0bbd8175aR2) [[2]](diffhunk://#diff-579d24752eacacc988aed2e3ad800b5a1168c54143e375216adad6e0bbd8175aR15-R53)

**Testing enhancements:**

* Added tests to confirm that the marker frame's dimensions remain constant regardless of the scale prop, and that the frame is correctly sized at the maximum scale to prevent Android clipping.