### PR TITLE
addressed multiple wings creating duplicates

### DIFF
--- a/mobile/__tests__/services/BuildingDataService-test.ts
+++ b/mobile/__tests__/services/BuildingDataService-test.ts
@@ -194,6 +194,87 @@ test("returns empty polygons when no displayPolygon", async () => {
   expect(result[0].polygons).toEqual([]);
 });
 
+test("deduplicates entries with identical buildingLongName", async () => {
+  const wing1 = createApiBuilding({
+    Building: "JM-1",
+    Building_Long_Name: "Journalism Building",
+  });
+  const wing2 = createApiBuilding({
+    Building: "JM-2",
+    Building_Long_Name: "Journalism Building",
+  });
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => [wing1, wing2],
+  });
+
+  const result = await BuildingDataService.fetchBuildings();
+
+  expect(result).toHaveLength(1);
+  expect(result[0].buildingLongName).toBe("Journalism Building");
+});
+
+test("merges polygons from duplicate long-name entries into one building", async () => {
+  const polygon1 = {
+    type: "Polygon",
+    coordinates: [
+      [
+        [-73.58, 45.49],
+        [-73.57, 45.49],
+        [-73.57, 45.5],
+      ],
+    ],
+  };
+  const polygon2 = {
+    type: "Polygon",
+    coordinates: [
+      [
+        [-73.56, 45.51],
+        [-73.55, 45.51],
+        [-73.55, 45.52],
+      ],
+    ],
+  };
+  const wing1 = createApiBuilding({
+    Building: "JM-1",
+    Building_Long_Name: "Journalism Building",
+    Google_Place_Info: { displayPolygon: polygon1 },
+  });
+  const wing2 = createApiBuilding({
+    Building: "JM-2",
+    Building_Long_Name: "Journalism Building",
+    Google_Place_Info: { displayPolygon: polygon2 },
+  });
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => [wing1, wing2],
+  });
+
+  const result = await BuildingDataService.fetchBuildings();
+
+  expect(result).toHaveLength(1);
+  expect(result[0].polygons).toHaveLength(2);
+});
+
+test("preserves distinct buildings with different buildingLongName", async () => {
+  const hall = createApiBuilding({
+    Building: "H",
+    Building_Long_Name: "Henry F. Hall Building",
+  });
+  const ev = createApiBuilding({
+    Building: "EV",
+    Building_Long_Name: "Engineering and Visual Arts Building",
+  });
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => [hall, ev],
+  });
+
+  const result = await BuildingDataService.fetchBuildings();
+
+  expect(result).toHaveLength(2);
+});
+
 test("maps Accessibility_Info field correctly", async () => {
   const apiBuilding = createApiBuilding({
     Accessibility_Info: "Some accessibility info",

--- a/mobile/src/services/BuildingDataService.ts
+++ b/mobile/src/services/BuildingDataService.ts
@@ -5,6 +5,23 @@ type Coordinate = number[];
 
 const API_BASE_URL = API_CONFIG.getBaseUrl();
 
+function deduplicateBuildings(buildings: Building[]): Building[] {
+  const seen = new Map<string, Building>();
+  for (const building of buildings) {
+    const key = building.buildingLongName;
+    const existing = seen.get(key);
+    if (!existing) {
+      seen.set(key, building);
+    } else {
+      seen.set(key, {
+        ...existing,
+        polygons: [...(existing.polygons ?? []), ...(building.polygons ?? [])],
+      });
+    }
+  }
+  return Array.from(seen.values());
+}
+
 export class BuildingDataService {
   static async fetchBuildings(): Promise<Building[]> {
     try {
@@ -16,7 +33,7 @@ export class BuildingDataService {
 
       const data = await response.json();
 
-      return data.map((building: any) => {
+      const buildings = data.map((building: any) => {
         let polygons: { latitude: number; longitude: number }[][] = [];
         const displayPolygon = building.Google_Place_Info?.displayPolygon;
 
@@ -76,6 +93,8 @@ export class BuildingDataService {
           Google_Place_Info: building.Google_Place_Info,
         };
       });
+
+      return deduplicateBuildings(buildings);
     } catch (error) {
       console.error("Error fetching buildings:", error);
       if (

--- a/mobile/src/services/BuildingDataService.ts
+++ b/mobile/src/services/BuildingDataService.ts
@@ -10,13 +10,13 @@ function deduplicateBuildings(buildings: Building[]): Building[] {
   for (const building of buildings) {
     const key = building.buildingLongName;
     const existing = seen.get(key);
-    if (!existing) {
-      seen.set(key, building);
-    } else {
+    if (existing) {
       seen.set(key, {
         ...existing,
         polygons: [...(existing.polygons ?? []), ...(building.polygons ?? [])],
       });
+    } else {
+      seen.set(key, building);
     }
   }
   return Array.from(seen.values());


### PR DESCRIPTION
This pull request enhances the handling of building data by ensuring that buildings with identical `buildingLongName` values are deduplicated and their polygons are merged. It also adds comprehensive tests to verify this new behavior and to ensure that distinct buildings remain separate.

### Building deduplication and polygon merging

* Introduced a new `deduplicateBuildings` function in `BuildingDataService` to merge entries with the same `buildingLongName`, combining their polygons into a single building entry.
* Updated the `fetchBuildings` method to use the new deduplication logic after mapping API data to building objects. [[1]](diffhunk://#diff-b3c7829d016b3fa6605d38086b4d7cd944d426f5560e7d7660e0c6d95c5c3eb4L19-R36) [[2]](diffhunk://#diff-b3c7829d016b3fa6605d38086b4d7cd944d426f5560e7d7660e0c6d95c5c3eb4R96-R97)

### Testing enhancements

* Added tests to verify that:
  - Duplicate buildings with the same `buildingLongName` are deduplicated.
  - Polygons from duplicate entries are merged.
  - Buildings with distinct `buildingLongName` values remain separate.