### PR TITLE
feat: enhance direction panel to support room as starting location

### DIFF
--- a/mobile/__tests__/components/DirectionPanel-test.tsx
+++ b/mobile/__tests__/components/DirectionPanel-test.tsx
@@ -241,6 +241,7 @@ jest.mock("../../../assets/car.png", () => 4, { virtual: true });
 interface Props {
   visible?: boolean;
   building?: Building | null;
+  roomLabel?: string | null;
   startBuilding?: Building | null;
   startRoom?: IndoorRoom | null;
   route?: RouteInfo | null;
@@ -267,6 +268,7 @@ function renderPanel(overrides: Props = {}) {
   const props = {
     visible: true,
     building: hallBuilding,
+    roomLabel: null,
     startBuilding: null,
     startRoom: null,
     route: null,
@@ -357,6 +359,11 @@ describe("DirectionPanel", () => {
     const building = { ...hallBuilding, buildingName: null as any };
     renderPanel({ building });
     expect(screen.getByText("H")).toBeTruthy();
+  });
+
+  it("shows room destination and building on one line when roomLabel is provided", () => {
+    renderPanel({ roomLabel: "H-920" });
+    expect(screen.getByText("H-920 (Hall Building)")).toBeTruthy();
   });
 
   // ── Distance text ──

--- a/mobile/__tests__/components/DirectionPanel-test.tsx
+++ b/mobile/__tests__/components/DirectionPanel-test.tsx
@@ -8,6 +8,7 @@ import {
   RouteInfo,
   TravelMode,
 } from "../../src/types/Directions";
+import { IndoorRoom } from "../../src/types/IndoorRoom";
 import { hallBuilding, libraryBuilding, makeRoute } from "../fixtures";
 
 // ── Mocks ──
@@ -241,6 +242,7 @@ interface Props {
   visible?: boolean;
   building?: Building | null;
   startBuilding?: Building | null;
+  startRoom?: IndoorRoom | null;
   route?: RouteInfo | null;
   routeLoading?: boolean;
   routeError?: string | null;
@@ -266,6 +268,7 @@ function renderPanel(overrides: Props = {}) {
     visible: true,
     building: hallBuilding,
     startBuilding: null,
+    startRoom: null,
     route: null,
     routeLoading: false,
     routeError: null,
@@ -383,10 +386,26 @@ describe("DirectionPanel", () => {
     expect(screen.getByText("Starting at Library Building")).toBeTruthy();
   });
 
+  it("shows room label and building name when classroom start is set", () => {
+    const startRoom: IndoorRoom = {
+      id: "room-h920",
+      buildingId: "Hall",
+      floor: 9,
+      label: "H-920",
+      x: 12,
+      y: 28,
+      type: "room",
+      accessible: true,
+    };
+
+    renderPanel({ startBuilding: hallBuilding, startRoom });
+    expect(screen.getByText("Starting at H-920 (Hall Building)")).toBeTruthy();
+  });
+
   it("calls onOpenSearch when change is pressed", () => {
     const { props } = renderPanel();
     fireEvent.press(
-      screen.getByLabelText("Search buildings to change directions start"),
+      screen.getByLabelText("Search locations to change directions start"),
     );
     expect(props.onOpenSearch).toHaveBeenCalledTimes(1);
   });

--- a/mobile/__tests__/components/GoogleMaps-test.tsx
+++ b/mobile/__tests__/components/GoogleMaps-test.tsx
@@ -22,6 +22,9 @@ const defaultMapUIState = {
   currentBuilding: null,
   searchOrigin: "default" as const,
   startBuilding: null,
+  startRoom: null,
+  destinationRoom: null,
+  indoorSelectedRoom: null,
   travelMode: null,
   route: null,
   routeLoading: false,
@@ -203,6 +206,7 @@ jest.mock("../../src/components/LocationScreen/DirectionPanel", () => {
         <Text testID="dp-start-building">
           {props.startBuilding?.buildingCode ?? "null"}
         </Text>
+        <Text testID="dp-room-label">{props.roomLabel ?? "null"}</Text>
         <Text testID="dp-has-route">{String(props.route != null)}</Text>
         <Text testID="dp-route-loading">{String(props.routeLoading)}</Text>
         <Text testID="dp-route-error">{props.routeError ?? "null"}</Text>
@@ -744,6 +748,27 @@ describe("GoogleMaps", () => {
     } as any;
     render(<GoogleMaps />);
     expect(screen.getByTestId("dp-start-building").children[0]).toBe("EV");
+  });
+
+  it("passes destination room label to DirectionPanel when panel is directions", () => {
+    mockMapUIState = {
+      ...defaultMapUIState,
+      panel: "directions",
+      destinationRoom: mockRoom,
+    } as any;
+    render(<GoogleMaps />);
+    expect(screen.getByTestId("dp-room-label").children[0]).toBe("H-920");
+  });
+
+  it("prefers indoor selected room label in room-info mode", () => {
+    mockMapUIState = {
+      ...defaultMapUIState,
+      panel: "room-info",
+      destinationRoom: { ...mockRoom, label: "H-920" },
+      indoorSelectedRoom: { ...mockRoom, label: "H-927" },
+    } as any;
+    render(<GoogleMaps />);
+    expect(screen.getByTestId("dp-room-label").children[0]).toBe("H-927");
   });
 
   it("passes route to DirectionPanel", () => {

--- a/mobile/__tests__/components/StepsPanel-test.tsx
+++ b/mobile/__tests__/components/StepsPanel-test.tsx
@@ -62,6 +62,22 @@ const route: RouteInfo = {
   ],
 };
 
+const sameBuildingStartRoom = {
+  id: "H-899-51",
+  label: "H-899-51",
+  buildingId: "H",
+  nodeType: "room",
+  floor: 8,
+} as any;
+
+const sameBuildingDestinationRoom = {
+  id: "H-920",
+  label: "H-920",
+  buildingId: "H",
+  nodeType: "room",
+  floor: 9,
+} as any;
+
 const transitRoute: RouteInfo = {
   coordinates: [],
   distanceMeters: 5000,
@@ -139,6 +155,22 @@ describe("StepsPanel", () => {
     expect(
       screen.getByText(/Exit Engineering and Visual Arts Complex/),
     ).toBeTruthy();
+  });
+
+  it("hides start exit row for same-building room routes", () => {
+    render(
+      <StepsPanel
+        building={building}
+        startBuilding={building}
+        route={route}
+        departureConfig={DEFAULT_DEPARTURE_CONFIG}
+        onBack={onBack}
+        startRoom={sameBuildingStartRoom}
+        destinationRoom={sameBuildingDestinationRoom}
+      />,
+    );
+
+    expect(screen.queryByText(/Exit H starting from room H-899-51/)).toBeNull();
   });
 
   it("calls onBack when back button pressed", () => {
@@ -468,5 +500,25 @@ describe("StepsPanel", () => {
     expect(btn).toBeTruthy();
     fireEvent.press(btn);
     expect(onOpenIndoor).toHaveBeenCalled();
+  });
+
+  it("hides arrival row and indoor map button for same-building room routes", () => {
+    const onOpenIndoor = jest.fn();
+
+    render(
+      <StepsPanel
+        startBuilding={building}
+        building={building}
+        route={route}
+        departureConfig={DEFAULT_DEPARTURE_CONFIG}
+        onBack={onBack}
+        startRoom={sameBuildingStartRoom}
+        destinationRoom={sameBuildingDestinationRoom}
+        onOpenIndoor={onOpenIndoor}
+      />,
+    );
+
+    expect(screen.queryByText(/Arrive at Hall Building/)).toBeNull();
+    expect(screen.queryByLabelText("Show Indoor Map")).toBeNull();
   });
 });

--- a/mobile/__tests__/hooks/useDirections-test.ts
+++ b/mobile/__tests__/hooks/useDirections-test.ts
@@ -1,13 +1,13 @@
 import { renderHook, waitFor } from "@testing-library/react-native";
 import { useDirections } from "../../src/hooks/useDirections";
 import { DirectionsService } from "../../src/services/DirectionsService";
+import { IndoorPathfindingService } from "../../src/services/IndoorPathfindingService";
+import { ShuttleDirectionsBuilder } from "../../src/services/ShuttleDirectionsBuilder";
 import { Building, StructureType } from "../../src/types/Building";
 import {
   DEFAULT_DEPARTURE_CONFIG,
   RouteInfo,
 } from "../../src/types/Directions";
-import { ShuttleDirectionsBuilder } from "../../src/services/ShuttleDirectionsBuilder";
-import { IndoorPathfindingService } from "../../src/services/IndoorPathfindingService";
 
 jest.mock("../../src/services/DirectionsService");
 jest.mock("../../src/services/ShuttleDirectionsBuilder");
@@ -462,15 +462,18 @@ describe("useDirections", () => {
 
     expect(onLoading).toHaveBeenCalled();
 
-    await waitFor(() =>
-      expect(onLoaded).toHaveBeenCalledWith(
-        expect.objectContaining({
-          distanceMeters: 100,
-          durationSeconds: 120,
-          indoorPath: [startRoom, destRoom],
-        }),
-      ),
+    await waitFor(() => expect(onLoaded).toHaveBeenCalled());
+
+    const finalRoute = onLoaded.mock.calls[0][0];
+    expect(finalRoute).toEqual(
+      expect.objectContaining({
+        distanceMeters: 100,
+        durationSeconds: 120,
+        indoorPath: [startRoom, destRoom],
+      }),
     );
+    expect(finalRoute.indoorPathOrigin).toBeUndefined();
+    expect(IndoorPathfindingService.getDirections).toHaveBeenCalledTimes(1);
   });
 
   it("calls onError if indoor pathfinding fails", async () => {

--- a/mobile/src/components/LocationScreen/DirectionPanel.tsx
+++ b/mobile/src/components/LocationScreen/DirectionPanel.tsx
@@ -16,14 +16,18 @@ import { usePanelAnimation } from "../../hooks/usePanelAnimation";
 import type { RoutePreviews } from "../../hooks/useRoutePreviews";
 import styles from "../../styles/DirectionPanel";
 import { Building, StructureType } from "../../types/Building";
-import { IndoorRoom } from "../../types/IndoorRoom";
 import {
   DepartureTimeConfig,
   RouteInfo,
   TRAVEL_MODE,
   TravelMode,
 } from "../../types/Directions";
-import { getBirdsEyeDistanceText } from "../../utils/directionsUtils";
+import { IndoorRoom } from "../../types/IndoorRoom";
+import {
+  getBirdsEyeDistanceText,
+  getDirectionOriginCoords,
+  getStartLocationText,
+} from "../../utils/directionsUtils";
 import { formatDuration } from "../../utils/formatHelper";
 import Tooltip from "../common/Tooltip";
 import DepartureTimePicker from "./DepartureTimePicker";
@@ -87,10 +91,12 @@ interface DirectionPanelProps {
 
 function StartLocationRow({
   startBuilding,
+  startRoom,
   onOpenSearch,
   onResetStart,
 }: Readonly<{
   startBuilding: Building | null | undefined;
+  startRoom: IndoorRoom | null | undefined;
   onOpenSearch?: () => void;
   onResetStart?: () => void;
 }>) {
@@ -100,13 +106,11 @@ function StartLocationRow({
         style={styles.changeStartRow}
         onPress={() => onOpenSearch?.()}
         disabled={!onOpenSearch}
-        accessibilityLabel="Search buildings to change directions start"
+        accessibilityLabel="Search locations to change directions start"
         accessibilityRole="button"
       >
         <Text style={styles.changeStartText} testID="start-location">
-          {startBuilding
-            ? `Starting at ${startBuilding.buildingName ?? startBuilding.buildingCode}`
-            : "Starting from your current location"}
+          {getStartLocationText(startBuilding, startRoom)}
         </Text>
         <Text style={styles.changeStart} testID="change-start">
           change
@@ -371,12 +375,11 @@ export default function DirectionPanel({
     return "-- min";
   };
 
-  const originCoords = startBuilding
-    ? {
-        latitude: startBuilding.latitude,
-        longitude: startBuilding.longitude,
-      }
-    : userLocation;
+  const originCoords = getDirectionOriginCoords(
+    startBuilding,
+    startRoom,
+    userLocation,
+  );
 
   const distanceText = getBirdsEyeDistanceText(originCoords, building);
 
@@ -423,6 +426,7 @@ export default function DirectionPanel({
 
             <StartLocationRow
               startBuilding={startBuilding}
+              startRoom={startRoom}
               onOpenSearch={onOpenSearch}
               onResetStart={onResetStart}
             />

--- a/mobile/src/components/LocationScreen/DirectionPanel.tsx
+++ b/mobile/src/components/LocationScreen/DirectionPanel.tsx
@@ -363,6 +363,13 @@ export default function DirectionPanel({
 }: Readonly<DirectionPanelProps>) {
   const { animatedStyle } = usePanelAnimation(visible);
 
+  const destinationBuildingName =
+    building?.buildingName ?? building?.buildingCode ?? "";
+  const destinationTitle = roomLabel
+    ? `${roomLabel} (${destinationBuildingName})`
+    : destinationBuildingName;
+  const destinationSubtitle = building?.address ?? "";
+
   // helper: get duration label for a mode
   const getDuration = (mode: TravelMode): string => {
     // If this mode is the active one and we have a full route, prefer that
@@ -413,12 +420,10 @@ export default function DirectionPanel({
             <View style={styles.buildingInfoRow}>
               <View style={styles.headerLeft}>
                 <Text style={styles.buildingName} numberOfLines={1}>
-                  {roomLabel ?? building.buildingName ?? building.buildingCode}
+                  {destinationTitle}
                 </Text>
                 <Text style={styles.buildingAddress} numberOfLines={2}>
-                  {roomLabel
-                    ? (building.buildingName ?? building.buildingCode)
-                    : (building.address ?? "")}
+                  {destinationSubtitle}
                 </Text>
               </View>
               <Text style={styles.distanceText}>{distanceText}</Text>

--- a/mobile/src/components/LocationScreen/GoogleMaps.tsx
+++ b/mobile/src/components/LocationScreen/GoogleMaps.tsx
@@ -235,8 +235,10 @@ export default function GoogleMaps({
         building={state.selectedBuilding}
         roomLabel={
           state.panel === "room-info"
-            ? (state.indoorSelectedRoom?.label ?? null)
-            : null
+            ? (state.indoorSelectedRoom?.label ??
+              state.destinationRoom?.label ??
+              null)
+            : (state.destinationRoom?.label ?? null)
         }
         startBuilding={state.startBuilding}
         route={state.route}

--- a/mobile/src/components/LocationScreen/StepsPanel.tsx
+++ b/mobile/src/components/LocationScreen/StepsPanel.tsx
@@ -4,8 +4,8 @@ import { Pressable, ScrollView, Text, View } from "react-native";
 import { COLORS } from "../../constants";
 import styles from "../../styles/StepsPanel";
 import { Building } from "../../types/Building";
-import { IndoorRoom } from "../../types/IndoorRoom";
 import { DepartureTimeConfig, RouteInfo } from "../../types/Directions";
+import { IndoorRoom } from "../../types/IndoorRoom";
 import {
   computeStepTimeline,
   getDepartureDate,
@@ -49,6 +49,10 @@ export default function StepsPanel({
   );
   const { visibleSteps, stepTimes, departureDate, arrivalDate } =
     computeStepTimeline(route.steps, initialDeparture);
+  const isSameBuildingRoomRoute =
+    !!startRoom?.buildingId &&
+    !!destinationRoom?.buildingId &&
+    startRoom.buildingId === destinationRoom.buildingId;
 
   return (
     <View style={styles.container}>
@@ -112,7 +116,7 @@ export default function StepsPanel({
         showsVerticalScrollIndicator
         onStartShouldSetResponder={() => true}
       >
-        {startBuilding && (
+        {startBuilding && !isSameBuildingRoomRoute && (
           <View
             key={`step-start-${startBuilding.buildingCode}`}
             style={styles.stepRow}
@@ -186,54 +190,56 @@ export default function StepsPanel({
         ))}
 
         {/* Arrival row */}
-        <View style={styles.stepRow}>
-          <View style={styles.stepContent}>
-            <Text style={styles.stepTimestamp}>
-              {formatDateTime(arrivalDate)}
-            </Text>
-            <Text style={styles.stepInstruction}>
-              Arrive at {building.buildingName ?? building.buildingCode}
-            </Text>
-            {destinationRoom && onOpenIndoor && (
-              <Pressable
-                style={{
-                  marginTop: 12,
-                  backgroundColor: COLORS.concordiaMaroon,
-                  paddingVertical: 10,
-                  paddingHorizontal: 16,
-                  borderRadius: 8,
-                  alignSelf: "flex-start",
-                  flexDirection: "row",
-                  alignItems: "center",
-                }}
-                onPress={onOpenIndoor}
-                accessibilityLabel="Show Indoor Map"
-                accessibilityRole="button"
-              >
-                <MaterialIcons
-                  name="map"
-                  size={18}
-                  color={COLORS.white}
-                  style={{ marginRight: 6 }}
-                />
-                <Text
+        {!isSameBuildingRoomRoute && (
+          <View style={styles.stepRow}>
+            <View style={styles.stepContent}>
+              <Text style={styles.stepTimestamp}>
+                {formatDateTime(arrivalDate)}
+              </Text>
+              <Text style={styles.stepInstruction}>
+                Arrive at {building.buildingName ?? building.buildingCode}
+              </Text>
+              {destinationRoom && onOpenIndoor && (
+                <Pressable
                   style={{
-                    color: COLORS.white,
-                    fontWeight: "600",
-                    fontSize: 14,
+                    marginTop: 12,
+                    backgroundColor: COLORS.concordiaMaroon,
+                    paddingVertical: 10,
+                    paddingHorizontal: 16,
+                    borderRadius: 8,
+                    alignSelf: "flex-start",
+                    flexDirection: "row",
+                    alignItems: "center",
                   }}
+                  onPress={onOpenIndoor}
+                  accessibilityLabel="Show Indoor Map"
+                  accessibilityRole="button"
                 >
-                  Show Indoor Map
-                </Text>
-              </Pressable>
-            )}
+                  <MaterialIcons
+                    name="map"
+                    size={18}
+                    color={COLORS.white}
+                    style={{ marginRight: 6 }}
+                  />
+                  <Text
+                    style={{
+                      color: COLORS.white,
+                      fontWeight: "600",
+                      fontSize: 14,
+                    }}
+                  >
+                    Show Indoor Map
+                  </Text>
+                </Pressable>
+              )}
+            </View>
+            <MaterialIcons
+              name="place"
+              size={42}
+              color={COLORS.concordiaMaroon}
+            />
           </View>
-          <MaterialIcons
-            name="place"
-            size={42}
-            color={COLORS.concordiaMaroon}
-          />
-        </View>
+        )}
       </ScrollView>
     </View>
   );

--- a/mobile/src/hooks/useDirections.ts
+++ b/mobile/src/hooks/useDirections.ts
@@ -290,6 +290,50 @@ export function useDirections({
     }
   };
 
+  const appendIndoorSegmentsIfNeeded = async (route: RouteInfo | null) => {
+    if (!route) {
+      return route;
+    }
+
+    const isPureIndoorSameBuildingRoute =
+      !!startRoom?.buildingId &&
+      startRoom.buildingId === destinationRoom?.buildingId;
+
+    if (isPureIndoorSameBuildingRoute) {
+      return route;
+    }
+
+    // If outdoor route was fetched but we have a start room, fetch the indoor departure path
+    if (!route.indoorPathOrigin && startRoom) {
+      try {
+        const indoorDeparture = await fetchIndoorDeparturePath(startRoom);
+        route.indoorPathOrigin = indoorDeparture.pathOrigin;
+        route.indoorStepsOrigin = indoorDeparture.stepsOrigin;
+      } catch (e) {
+        console.warn(
+          "Could not compute indoor->outdoor departure path segment:",
+          e,
+        );
+      }
+    }
+
+    // If outdoor route was fetched but we have a destination room, fetch the indoor arrival path
+    if (!route.indoorPath && destinationRoom) {
+      try {
+        const indoorArrival = await fetchIndoorArrivalPath(destinationRoom);
+        route.indoorPath = indoorArrival.path;
+        route.indoorSteps = indoorArrival.steps;
+      } catch (e) {
+        console.warn(
+          "Could not compute outdoor->indoor arrival path segment:",
+          e,
+        );
+      }
+    }
+
+    return route;
+  };
+
   useEffect(() => {
     if (!active || !destination || travelMode == null) return;
 
@@ -326,9 +370,7 @@ export function useDirections({
     const fetchRoute = async () => {
       onLoading();
       try {
-        let route;
-
-        route = await getRoute({
+        const route = await getRoute({
           originLat,
           originLng,
           destination,
@@ -340,36 +382,9 @@ export function useDirections({
           arrivalTime,
           departureConfig,
         });
+        const augmentedRoute = await appendIndoorSegmentsIfNeeded(route);
 
-        // If outdoor route was fetched but we have a start room, fetch the indoor departure path
-        if (route && !route.indoorPathOrigin && startRoom) {
-          try {
-            const indoorDeparture = await fetchIndoorDeparturePath(startRoom);
-            route.indoorPathOrigin = indoorDeparture.pathOrigin;
-            route.indoorStepsOrigin = indoorDeparture.stepsOrigin;
-          } catch (e) {
-            console.warn(
-              "Could not compute indoor->outdoor departure path segment:",
-              e,
-            );
-          }
-        }
-
-        // If outdoor route was fetched but we have a destination room, fetch the indoor arrival path
-        if (route && !route.indoorPath && destinationRoom) {
-          try {
-            const indoorArrival = await fetchIndoorArrivalPath(destinationRoom);
-            route.indoorPath = indoorArrival.path;
-            route.indoorSteps = indoorArrival.steps;
-          } catch (e) {
-            console.warn(
-              "Could not compute outdoor->indoor arrival path segment:",
-              e,
-            );
-          }
-        }
-
-        if (!cancelled) onLoaded(route);
+        if (!cancelled) onLoaded(augmentedRoute);
       } catch (err) {
         if (!cancelled) {
           onError(

--- a/mobile/src/hooks/useDirections.ts
+++ b/mobile/src/hooks/useDirections.ts
@@ -1,9 +1,8 @@
 import { useEffect, useRef } from "react";
 import { DirectionsService } from "../services/DirectionsService";
-import { ShuttleDirectionsBuilder } from "../services/ShuttleDirectionsBuilder";
 import { IndoorPathfindingService } from "../services/IndoorPathfindingService";
+import { ShuttleDirectionsBuilder } from "../services/ShuttleDirectionsBuilder";
 import { Building } from "../types/Building";
-import { IndoorRoom } from "../types/IndoorRoom";
 import {
   DepartureTimeConfig,
   RouteInfo,
@@ -11,6 +10,8 @@ import {
   TRAVEL_MODE,
   TravelMode,
 } from "../types/Directions";
+import { IndoorRoom } from "../types/IndoorRoom";
+import { getDirectionOriginCoords } from "../utils/directionsUtils";
 
 const getEdgeNodes = (bId: string, IndoorDataService: any) => {
   const nodes = IndoorDataService.getAllNodes();
@@ -293,8 +294,13 @@ export function useDirections({
     if (!active || !destination || travelMode == null) return;
 
     // Determine the origin coordinates
-    const originLat = startBuilding?.latitude ?? userLocation?.latitude;
-    const originLng = startBuilding?.longitude ?? userLocation?.longitude;
+    const originCoords = getDirectionOriginCoords(
+      startBuilding,
+      startRoom,
+      userLocation,
+    );
+    const originLat = originCoords?.latitude;
+    const originLng = originCoords?.longitude;
 
     if (originLat == null || originLng == null) return;
 

--- a/mobile/src/hooks/useMapUI.ts
+++ b/mobile/src/hooks/useMapUI.ts
@@ -77,6 +77,7 @@ export function useMapUI(
   const routePreviews = useRoutePreviews({
     destination: state.selectedBuilding,
     startBuilding: state.startBuilding,
+    startRoom: state.startRoom,
     userLocation: userCoords,
     departureConfig: state.departureConfig,
     active: state.panel === "directions" || state.panel === "room-info",

--- a/mobile/src/hooks/useRoutePreviews.ts
+++ b/mobile/src/hooks/useRoutePreviews.ts
@@ -8,12 +8,15 @@ import {
   TRAVEL_MODE,
   TravelMode,
 } from "../types/Directions";
+import { IndoorRoom } from "../types/IndoorRoom";
+import { getDirectionOriginCoords } from "../utils/directionsUtils";
 
 export type RoutePreviews = Partial<Record<TravelMode, number | null>>;
 
 interface UseRoutePreviewsParams {
   destination: Building | null;
   startBuilding: Building | null;
+  startRoom: IndoorRoom | null;
   userLocation: { latitude: number; longitude: number } | null;
   departureConfig: DepartureTimeConfig;
   active: boolean;
@@ -27,6 +30,7 @@ interface UseRoutePreviewsParams {
 export function useRoutePreviews({
   destination,
   startBuilding,
+  startRoom,
   userLocation,
   departureConfig,
   active,
@@ -39,8 +43,13 @@ export function useRoutePreviews({
       return;
     }
 
-    const originLat = startBuilding?.latitude ?? userLocation?.latitude;
-    const originLng = startBuilding?.longitude ?? userLocation?.longitude;
+    const originCoords = getDirectionOriginCoords(
+      startBuilding,
+      startRoom,
+      userLocation,
+    );
+    const originLat = originCoords?.latitude;
+    const originLng = originCoords?.longitude;
 
     if (originLat == null || originLng == null) return;
 
@@ -113,6 +122,7 @@ export function useRoutePreviews({
     active,
     destination?.buildingCode,
     startBuilding?.buildingCode,
+    startRoom?.id,
     userLocation?.latitude,
     userLocation?.longitude,
     departureConfig.option,

--- a/mobile/src/utils/directionsUtils.ts
+++ b/mobile/src/utils/directionsUtils.ts
@@ -1,6 +1,8 @@
 import type MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { ComponentProps } from "react";
+import { Building } from "../types/Building";
 import { DepartureTimeConfig, StepInfo } from "../types/Directions";
+import { IndoorRoom } from "../types/IndoorRoom";
 import { calculateDistance } from "./buildingDetection";
 import { formatDistance } from "./formatHelper";
 
@@ -9,6 +11,49 @@ type MaterialIconName = ComponentProps<typeof MaterialIcons>["name"];
 interface LatLng {
   latitude: number;
   longitude: number;
+}
+
+function getBuildingDisplayName(building: Building): string {
+  return building.buildingName ?? building.buildingCode;
+}
+
+/**
+ * Returns the effective outdoor origin coordinates for direction calculations.
+ * Classroom starts currently resolve to their building coordinates.
+ */
+export function getDirectionOriginCoords(
+  startBuilding: Building | null | undefined,
+  startRoom: IndoorRoom | null | undefined,
+  userLocation: LatLng | null | undefined,
+): LatLng | null {
+  if (startBuilding) {
+    return {
+      latitude: startBuilding.latitude,
+      longitude: startBuilding.longitude,
+    };
+  }
+
+  // A room-only start without a mapped building has no outdoor coordinates yet.
+  if (startRoom) {
+    return userLocation ?? null;
+  }
+
+  return userLocation ?? null;
+}
+
+export function getStartLocationText(
+  startBuilding: Building | null | undefined,
+  startRoom: IndoorRoom | null | undefined,
+): string {
+  if (!startBuilding) {
+    return "Starting from your current location";
+  }
+
+  if (startRoom?.label) {
+    return `Starting at ${startRoom.label} (${getBuildingDisplayName(startBuilding)})`;
+  }
+
+  return `Starting at ${getBuildingDisplayName(startBuilding)}`;
 }
 
 export function getBirdsEyeDistanceText(


### PR DESCRIPTION
This pull request enhances the handling of directions starting from specific indoor rooms (such as classrooms), rather than just buildings, across the mobile app. The main improvements involve supporting a `startRoom` parameter in relevant components, hooks, and utilities, so that the UI and direction calculations can reflect when a user starts from a particular room within a building.

The most important changes are:

**Support for indoor room as direction origin:**

* Added a `startRoom` prop to the `DirectionPanel` component and its test, and updated the UI to show both room and building when a classroom start is set. [[1]](diffhunk://#diff-82e7d57658d46f584426426517d92cd582a10e9354dec968256054f8b5f2de22R94-R99) [[2]](diffhunk://#diff-82e7d57658d46f584426426517d92cd582a10e9354dec968256054f8b5f2de22R429) [[3]](diffhunk://#diff-e87613f722923322026de350b8164bd65ef8c831a5524b736447e73f44c08966R245) [[4]](diffhunk://#diff-e87613f722923322026de350b8164bd65ef8c831a5524b736447e73f44c08966R389-R408)
* Updated hooks (`useDirections`, `useRoutePreviews`, and `useMapUI`) to accept and use `startRoom` for calculating origin coordinates and route previews. [[1]](diffhunk://#diff-59bb833df78766fe8e273de60d82f47a40664295aa444a8c2373aa4175fac247L296-R303) [[2]](diffhunk://#diff-41bb8440cd8fbd0d754e49f6e04d31bbb66c3a689d82465fd43952d27918fc44R33) [[3]](diffhunk://#diff-5f6dbe8943485e7f4c669c9b1154cf96cc668031275135d434ba7daad0c618b1R80)

**Centralized logic for direction origin and display:**

* Introduced `getDirectionOriginCoords` and `getStartLocationText` utility functions in `directionsUtils.ts` to consistently determine the origin coordinates and display text for both building and room starts. Updated relevant locations to use these utilities. [[1]](diffhunk://#diff-0b4489eb2d30c1db056dd0570538e494e044a233982d9fc5d5389a5951a32ef2R16-R58) [[2]](diffhunk://#diff-0b4489eb2d30c1db056dd0570538e494e044a233982d9fc5d5389a5951a32ef2R3-R5) [[3]](diffhunk://#diff-82e7d57658d46f584426426517d92cd582a10e9354dec968256054f8b5f2de22L103-R113) [[4]](diffhunk://#diff-41bb8440cd8fbd0d754e49f6e04d31bbb66c3a689d82465fd43952d27918fc44L42-R52) [[5]](diffhunk://#diff-82e7d57658d46f584426426517d92cd582a10e9354dec968256054f8b5f2de22L374-R382)
* Ensured that when a room is specified, but not a building, the origin falls back to the user's current location, and the display text reflects the most specific available information.

**Test improvements:**

* Added a test case to verify that the direction panel correctly displays both the room label and building name when a classroom start is set.

These changes improve the user experience when starting directions from a specific classroom or room, and lay the groundwork for more precise indoor navigation features.