### PR TITLE
changed colors depending on transportation mode

### DIFF
--- a/mobile/__tests__/components/GoogleMaps-test.tsx
+++ b/mobile/__tests__/components/GoogleMaps-test.tsx
@@ -1160,6 +1160,7 @@ describe("GoogleMaps", () => {
   it("renders route polyline when route has coordinates", () => {
     mockMapUIState = {
       ...defaultMapUIState,
+      panel: "directions",
       route: {
         coordinates: [
           { latitude: 45.4973, longitude: -73.5789 },
@@ -1179,6 +1180,7 @@ describe("GoogleMaps", () => {
   it("renders polyline without dash pattern for non-WALK mode", () => {
     mockMapUIState = {
       ...defaultMapUIState,
+      panel: "directions",
       route: {
         coordinates: [
           { latitude: 45.4973, longitude: -73.5789 },
@@ -1198,11 +1200,30 @@ describe("GoogleMaps", () => {
   it("does not render polyline when route has fewer than 2 coordinates", () => {
     mockMapUIState = {
       ...defaultMapUIState,
+      panel: "directions",
       route: {
         coordinates: [{ latitude: 45.4973, longitude: -73.5789 }],
         duration: 0,
         distance: 0,
       },
+    } as any;
+    render(<GoogleMaps />);
+    expect(screen.queryByTestId("route-polyline")).toBeNull();
+  });
+
+  it("does not render route polyline when directions panel is closed", () => {
+    mockMapUIState = {
+      ...defaultMapUIState,
+      panel: "none",
+      route: {
+        coordinates: [
+          { latitude: 45.4973, longitude: -73.5789 },
+          { latitude: 45.4957, longitude: -73.5773 },
+        ],
+        duration: 300,
+        distance: 500,
+      },
+      travelMode: "WALK",
     } as any;
     render(<GoogleMaps />);
     expect(screen.queryByTestId("route-polyline")).toBeNull();

--- a/mobile/__tests__/components/RoutePolyline-test.tsx
+++ b/mobile/__tests__/components/RoutePolyline-test.tsx
@@ -2,8 +2,8 @@ import { render } from "@testing-library/react-native";
 
 import RoutePolyline from "../../src/components/LocationScreen/RoutePolyline";
 import { COLORS } from "../../src/constants";
-import { TRAVEL_MODE, TravelMode } from "../../src/types/Directions";
-import { makeRoute } from "../fixtures";
+import { TRAVEL_MODE } from "../../src/types/Directions";
+import { makeRoute, makeStep } from "../fixtures";
 
 jest.mock("react-native-maps", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -52,69 +52,258 @@ describe("RoutePolyline", () => {
       expect(toJSON()).not.toBeNull();
     });
 
-    it("renders Polyline with correct coordinates", () => {
-      const route = makeRoute();
+    it("renders multiple Polyline segments (one per step)", () => {
+      const route = makeRoute({
+        steps: [
+          makeStep({ instruction: "Walk north" }),
+          makeStep({ instruction: "Turn left" }),
+          makeStep({ instruction: "Walk straight" }),
+        ],
+      });
       const view = render(
         <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
       );
       const json = view.toJSON() as any;
-      expect(json.props.coordinates).toEqual(route.coordinates);
+      // Should render 3 Polyline components (one per step)
+      expect(Array.isArray(json)).toBe(true);
+      expect(json.length).toBe(3);
     });
 
-    it("renders with strokeWidth of 5", () => {
-      const route = makeRoute();
+    it("renders single Polyline segment for route with no steps", () => {
+      const route = makeRoute({ steps: [] });
       const view = render(
         <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
       );
       const json = view.toJSON() as any;
-      expect(json.props.strokeWidth).toBe(5);
+      expect(json).not.toBeNull();
+      expect(json.props).toBeDefined();
+    });
+
+    it("renders with strokeWidth of 5 for each segment", () => {
+      const route = makeRoute({
+        steps: [makeStep({}), makeStep({})],
+      });
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
+      );
+      const json = view.toJSON() as any;
+      json.forEach((polyline: any) => {
+        expect(polyline.props.strokeWidth).toBe(5);
+      });
     });
   });
 
-  describe("walking mode", () => {
-    it("uses dark blue color for walking", () => {
-      const route = makeRoute();
-      const view = render(
-        <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
-      );
-      const json = view.toJSON() as any;
-      expect(json.props.strokeColor).toBe(COLORS.mapPolylineWalk);
-      expect(json.props.strokeColor).toBe("#40509F");
-    });
-
-    it("uses dotted line pattern for walking", () => {
-      const route = makeRoute();
-      const view = render(
-        <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
-      );
-      const json = view.toJSON() as any;
-      expect(json.props.lineDashPattern).toEqual([8, 6]);
-    });
-  });
-
-  describe("cycling mode", () => {
-    it("uses orange color for cycling", () => {
-      const route = makeRoute();
+  describe("cycling steps", () => {
+    it("uses orange color for cycling steps", () => {
+      const cycleStep = makeStep({ travelMode: "BICYCLE" });
+      const route = makeRoute({ steps: [cycleStep] });
       const view = render(
         <RoutePolyline route={route} travelMode={TRAVEL_MODE.BICYCLE} />,
       );
       const json = view.toJSON() as any;
-      expect(json.props.strokeColor).toBe("#FF8C00");
+      const polyline = Array.isArray(json) ? json[0] : json;
+      expect(polyline.props.strokeColor).toBe("#FF8C00");
     });
 
-    it("uses dashed line pattern for cycling", () => {
-      const route = makeRoute();
+    it("uses dashed line pattern for cycling steps", () => {
+      const cycleStep = makeStep({ travelMode: "BICYCLE" });
+      const route = makeRoute({ steps: [cycleStep] });
       const view = render(
         <RoutePolyline route={route} travelMode={TRAVEL_MODE.BICYCLE} />,
       );
       const json = view.toJSON() as any;
-      expect(json.props.lineDashPattern).toEqual([12, 6]);
+      const polyline = Array.isArray(json) ? json[0] : json;
+      expect(polyline.props.lineDashPattern).toEqual([12, 6]);
     });
   });
 
-  describe("shuttle mode", () => {
-    it("uses concordia maroon color for shuttle", () => {
-      const route = makeRoute();
+  describe("walking steps", () => {
+    it("uses dark blue color for walking steps", () => {
+      const walkStep = makeStep();
+      const route = makeRoute({ steps: [walkStep] });
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
+      );
+      const json = view.toJSON() as any;
+      const polyline = Array.isArray(json) ? json[0] : json;
+      expect(polyline.props.strokeColor).toBe("#40509F");
+    });
+
+    it("uses dotted line pattern for walking steps", () => {
+      const walkStep = makeStep();
+      const route = makeRoute({ steps: [walkStep] });
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
+      );
+      const json = view.toJSON() as any;
+      const polyline = Array.isArray(json) ? json[0] : json;
+      expect(polyline.props.lineDashPattern).toEqual([8, 6]);
+    });
+  });
+
+  describe("transit steps - vehicle types", () => {
+    it("uses orange-red color for subway/metro steps", () => {
+      const metroStep = makeStep({
+        transitDetails: {
+          departureStopName: "Guy-Concordia",
+          arrivalStopName: "Berri-UQAM",
+          departureTime: "2026-03-03T09:00:00Z",
+          arrivalTime: "2026-03-03T09:15:00Z",
+          lineName: "Green Line",
+          lineShortName: "1",
+          vehicleType: "SUBWAY",
+          vehicleName: "Metro",
+          stopCount: 5,
+        },
+      });
+      const route = makeRoute({ steps: [metroStep] });
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.TRANSIT} />,
+      );
+      const json = view.toJSON() as any;
+      const polyline = Array.isArray(json) ? json[0] : json;
+      expect(polyline.props.strokeColor).toBe("#FF6B35");
+    });
+
+    it("uses light blue color for bus steps", () => {
+      const busStep = makeStep({
+        transitDetails: {
+          departureStopName: "Guy-Concordia",
+          arrivalStopName: "Berri-UQAM",
+          departureTime: "2026-03-03T09:00:00Z",
+          arrivalTime: "2026-03-03T09:15:00Z",
+          lineName: "105",
+          lineShortName: "105",
+          vehicleType: "BUS",
+          vehicleName: "STM Bus",
+          stopCount: 3,
+        },
+      });
+      const route = makeRoute({ steps: [busStep] });
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.TRANSIT} />,
+      );
+      const json = view.toJSON() as any;
+      const polyline = Array.isArray(json) ? json[0] : json;
+      expect(polyline.props.strokeColor).toBe("#1E90FF");
+    });
+
+    it("uses royal blue color for trolleybus steps", () => {
+      const trolleyStep = makeStep({
+        transitDetails: {
+          departureStopName: "Stop A",
+          arrivalStopName: "Stop B",
+          departureTime: "2026-03-03T09:00:00Z",
+          arrivalTime: "2026-03-03T09:15:00Z",
+          lineName: "201",
+          lineShortName: "201",
+          vehicleType: "TROLLEYBUS",
+          vehicleName: "Trolleybus",
+          stopCount: 2,
+        },
+      });
+      const route = makeRoute({ steps: [trolleyStep] });
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.TRANSIT} />,
+      );
+      const json = view.toJSON() as any;
+      const polyline = Array.isArray(json) ? json[0] : json;
+      expect(polyline.props.strokeColor).toBe("#4169E1");
+    });
+
+    it("uses solid line for all transit steps", () => {
+      const transitStep = makeStep({
+        transitDetails: {
+          departureStopName: "Stop A",
+          arrivalStopName: "Stop B",
+          departureTime: "2026-03-03T09:00:00Z",
+          arrivalTime: "2026-03-03T09:15:00Z",
+          lineName: "105",
+          lineShortName: "105",
+          vehicleType: "BUS",
+          vehicleName: "Bus",
+          stopCount: 2,
+        },
+      });
+      const route = makeRoute({ steps: [transitStep] });
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.TRANSIT} />,
+      );
+      const json = view.toJSON() as any;
+      const polyline = Array.isArray(json) ? json[0] : json;
+      expect(polyline.props.lineDashPattern).toBeUndefined();
+    });
+  });
+
+  describe("mixed transit routes", () => {
+    it("renders walking + bus + metro + walking with different colors and styles", () => {
+      const route = makeRoute({
+        steps: [
+          // Walking to stop
+          makeStep({ instruction: "Walk to bus stop" }),
+          // Bus segment
+          makeStep({
+            instruction: "Take bus 105",
+            transitDetails: {
+              departureStopName: "Start",
+              arrivalStopName: "Transfer",
+              departureTime: "2026-03-03T09:00:00Z",
+              arrivalTime: "2026-03-03T09:10:00Z",
+              lineName: "105",
+              lineShortName: "105",
+              vehicleType: "BUS",
+              vehicleName: "Bus",
+              stopCount: 3,
+            },
+          }),
+          // Metro segment
+          makeStep({
+            instruction: "Take metro line 1",
+            transitDetails: {
+              departureStopName: "Transfer",
+              arrivalStopName: "Destination",
+              departureTime: "2026-03-03T09:15:00Z",
+              arrivalTime: "2026-03-03T09:25:00Z",
+              lineName: "Green Line",
+              lineShortName: "1",
+              vehicleType: "SUBWAY",
+              vehicleName: "Metro",
+              stopCount: 5,
+            },
+          }),
+          // Walking from stop
+          makeStep({ instruction: "Walk to destination" }),
+        ],
+      });
+
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.TRANSIT} />,
+      );
+      const json = view.toJSON() as any;
+      expect(Array.isArray(json)).toBe(true);
+      expect(json.length).toBe(4);
+
+      // Walking segment (index 0)
+      expect(json[0].props.strokeColor).toBe("#40509F");
+      expect(json[0].props.lineDashPattern).toEqual([8, 6]);
+
+      // Bus segment (index 1)
+      expect(json[1].props.strokeColor).toBe("#1E90FF");
+      expect(json[1].props.lineDashPattern).toBeUndefined();
+
+      // Metro segment (index 2)
+      expect(json[2].props.strokeColor).toBe("#FF6B35");
+      expect(json[2].props.lineDashPattern).toBeUndefined();
+
+      // Walking segment (index 3)
+      expect(json[3].props.strokeColor).toBe("#40509F");
+      expect(json[3].props.lineDashPattern).toEqual([8, 6]);
+    });
+  });
+
+  describe("default colors for entire route", () => {
+    it("uses concordia maroon for shuttle routes with no steps", () => {
+      const route = makeRoute({ steps: [] });
       const view = render(
         <RoutePolyline route={route} travelMode={TRAVEL_MODE.SHUTTLE} />,
       );
@@ -123,109 +312,22 @@ describe("RoutePolyline", () => {
       expect(json.props.strokeColor).toBe("#9C2D2D");
     });
 
-    it("uses solid line (no dash pattern) for shuttle", () => {
-      const route = makeRoute();
+    it("uses orange for bicycle routes with no steps", () => {
+      const route = makeRoute({ steps: [] });
       const view = render(
-        <RoutePolyline route={route} travelMode={TRAVEL_MODE.SHUTTLE} />,
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.BICYCLE} />,
       );
       const json = view.toJSON() as any;
-      expect(json.props.lineDashPattern).toBeUndefined();
+      expect(json.props.strokeColor).toBe("#FF8C00");
     });
-  });
 
-  describe("transit mode", () => {
-    it("uses light blue color for transit", () => {
-      const route = makeRoute();
+    it("uses dashed line for bicycle routes", () => {
+      const route = makeRoute({ steps: [] });
       const view = render(
-        <RoutePolyline route={route} travelMode={TRAVEL_MODE.TRANSIT} />,
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.BICYCLE} />,
       );
       const json = view.toJSON() as any;
-      expect(json.props.strokeColor).toBe("#1E90FF");
-    });
-
-    it("uses solid line (no dash pattern) for transit", () => {
-      const route = makeRoute();
-      const view = render(
-        <RoutePolyline route={route} travelMode={TRAVEL_MODE.TRANSIT} />,
-      );
-      const json = view.toJSON() as any;
-      expect(json.props.lineDashPattern).toBeUndefined();
-    });
-  });
-
-  describe("driving mode", () => {
-    it("uses dark blue color for driving", () => {
-      const route = makeRoute();
-      const view = render(
-        <RoutePolyline route={route} travelMode={TRAVEL_MODE.DRIVE} />,
-      );
-      const json = view.toJSON() as any;
-      expect(json.props.strokeColor).toBe(COLORS.mapPolylineWalk);
-      expect(json.props.strokeColor).toBe("#40509F");
-    });
-
-    it("uses solid line (no dash pattern) for driving", () => {
-      const route = makeRoute();
-      const view = render(
-        <RoutePolyline route={route} travelMode={TRAVEL_MODE.DRIVE} />,
-      );
-      const json = view.toJSON() as any;
-      expect(json.props.lineDashPattern).toBeUndefined();
-    });
-  });
-
-  describe("null travel mode", () => {
-    it("defaults to dark blue color when travelMode is null", () => {
-      const route = makeRoute();
-      const view = render(<RoutePolyline route={route} travelMode={null} />);
-      const json = view.toJSON() as any;
-      expect(json.props.strokeColor).toBe(COLORS.mapPolylineWalk);
-    });
-
-    it("uses dotted line pattern when travelMode is null", () => {
-      const route = makeRoute();
-      const view = render(<RoutePolyline route={route} travelMode={null} />);
-      const json = view.toJSON() as any;
-      expect(json.props.lineDashPattern).toEqual([8, 6]);
-    });
-  });
-
-  describe("all modes comparison", () => {
-    const modes: {
-      mode: TravelMode;
-      color: string;
-      hasDash: boolean;
-      dashPattern?: number[];
-    }[] = [
-      {
-        mode: TRAVEL_MODE.WALK,
-        color: "#40509F",
-        hasDash: true,
-        dashPattern: [8, 6],
-      },
-      {
-        mode: TRAVEL_MODE.BICYCLE,
-        color: "#FF8C00",
-        hasDash: true,
-        dashPattern: [12, 6],
-      },
-      { mode: TRAVEL_MODE.SHUTTLE, color: "#9C2D2D", hasDash: false },
-      { mode: TRAVEL_MODE.TRANSIT, color: "#1E90FF", hasDash: false },
-      { mode: TRAVEL_MODE.DRIVE, color: "#40509F", hasDash: false },
-    ];
-
-    modes.forEach(({ mode, color, hasDash, dashPattern }) => {
-      it(`applies correct styling for ${mode}`, () => {
-        const route = makeRoute();
-        const view = render(<RoutePolyline route={route} travelMode={mode} />);
-        const json = view.toJSON() as any;
-        expect(json.props.strokeColor).toBe(color);
-        if (hasDash) {
-          expect(json.props.lineDashPattern).toEqual(dashPattern);
-        } else {
-          expect(json.props.lineDashPattern).toBeUndefined();
-        }
-      });
+      expect(json.props.lineDashPattern).toEqual([12, 6]);
     });
   });
 });

--- a/mobile/__tests__/components/RoutePolyline-test.tsx
+++ b/mobile/__tests__/components/RoutePolyline-test.tsx
@@ -1,0 +1,231 @@
+import { render } from "@testing-library/react-native";
+
+import RoutePolyline from "../../src/components/LocationScreen/RoutePolyline";
+import { COLORS } from "../../src/constants";
+import { TRAVEL_MODE, TravelMode } from "../../src/types/Directions";
+import { makeRoute } from "../fixtures";
+
+jest.mock("react-native-maps", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require("react");
+  const PolylineMock = (props: any) =>
+    React.createElement("Polyline", props, props.children);
+  PolylineMock.displayName = "Polyline";
+  return {
+    __esModule: true,
+    Polyline: PolylineMock,
+  };
+});
+
+describe("RoutePolyline", () => {
+  describe("rendering", () => {
+    it("returns null when route is null", () => {
+      const { toJSON } = render(
+        <RoutePolyline route={null} travelMode={TRAVEL_MODE.WALK} />,
+      );
+      expect(toJSON()).toBeNull();
+    });
+
+    it("returns null when route has fewer than 2 coordinates", () => {
+      const route = makeRoute({
+        coordinates: [{ latitude: 45.4973, longitude: -73.5789 }],
+      });
+      const { toJSON } = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
+      );
+      expect(toJSON()).toBeNull();
+    });
+
+    it("returns null when route has empty coordinates", () => {
+      const route = makeRoute({ coordinates: [] });
+      const { toJSON } = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
+      );
+      expect(toJSON()).toBeNull();
+    });
+
+    it("renders Polyline when route has 2 or more coordinates", () => {
+      const route = makeRoute();
+      const { toJSON } = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
+      );
+      expect(toJSON()).not.toBeNull();
+    });
+
+    it("renders Polyline with correct coordinates", () => {
+      const route = makeRoute();
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
+      );
+      const json = view.toJSON() as any;
+      expect(json.props.coordinates).toEqual(route.coordinates);
+    });
+
+    it("renders with strokeWidth of 5", () => {
+      const route = makeRoute();
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
+      );
+      const json = view.toJSON() as any;
+      expect(json.props.strokeWidth).toBe(5);
+    });
+  });
+
+  describe("walking mode", () => {
+    it("uses dark blue color for walking", () => {
+      const route = makeRoute();
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
+      );
+      const json = view.toJSON() as any;
+      expect(json.props.strokeColor).toBe(COLORS.mapPolylineWalk);
+      expect(json.props.strokeColor).toBe("#40509F");
+    });
+
+    it("uses dotted line pattern for walking", () => {
+      const route = makeRoute();
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.WALK} />,
+      );
+      const json = view.toJSON() as any;
+      expect(json.props.lineDashPattern).toEqual([8, 6]);
+    });
+  });
+
+  describe("cycling mode", () => {
+    it("uses orange color for cycling", () => {
+      const route = makeRoute();
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.BICYCLE} />,
+      );
+      const json = view.toJSON() as any;
+      expect(json.props.strokeColor).toBe("#FF8C00");
+    });
+
+    it("uses dashed line pattern for cycling", () => {
+      const route = makeRoute();
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.BICYCLE} />,
+      );
+      const json = view.toJSON() as any;
+      expect(json.props.lineDashPattern).toEqual([12, 6]);
+    });
+  });
+
+  describe("shuttle mode", () => {
+    it("uses concordia maroon color for shuttle", () => {
+      const route = makeRoute();
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.SHUTTLE} />,
+      );
+      const json = view.toJSON() as any;
+      expect(json.props.strokeColor).toBe(COLORS.concordiaMaroon);
+      expect(json.props.strokeColor).toBe("#9C2D2D");
+    });
+
+    it("uses solid line (no dash pattern) for shuttle", () => {
+      const route = makeRoute();
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.SHUTTLE} />,
+      );
+      const json = view.toJSON() as any;
+      expect(json.props.lineDashPattern).toBeUndefined();
+    });
+  });
+
+  describe("transit mode", () => {
+    it("uses light blue color for transit", () => {
+      const route = makeRoute();
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.TRANSIT} />,
+      );
+      const json = view.toJSON() as any;
+      expect(json.props.strokeColor).toBe("#1E90FF");
+    });
+
+    it("uses solid line (no dash pattern) for transit", () => {
+      const route = makeRoute();
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.TRANSIT} />,
+      );
+      const json = view.toJSON() as any;
+      expect(json.props.lineDashPattern).toBeUndefined();
+    });
+  });
+
+  describe("driving mode", () => {
+    it("uses dark blue color for driving", () => {
+      const route = makeRoute();
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.DRIVE} />,
+      );
+      const json = view.toJSON() as any;
+      expect(json.props.strokeColor).toBe(COLORS.mapPolylineWalk);
+      expect(json.props.strokeColor).toBe("#40509F");
+    });
+
+    it("uses solid line (no dash pattern) for driving", () => {
+      const route = makeRoute();
+      const view = render(
+        <RoutePolyline route={route} travelMode={TRAVEL_MODE.DRIVE} />,
+      );
+      const json = view.toJSON() as any;
+      expect(json.props.lineDashPattern).toBeUndefined();
+    });
+  });
+
+  describe("null travel mode", () => {
+    it("defaults to dark blue color when travelMode is null", () => {
+      const route = makeRoute();
+      const view = render(<RoutePolyline route={route} travelMode={null} />);
+      const json = view.toJSON() as any;
+      expect(json.props.strokeColor).toBe(COLORS.mapPolylineWalk);
+    });
+
+    it("uses dotted line pattern when travelMode is null", () => {
+      const route = makeRoute();
+      const view = render(<RoutePolyline route={route} travelMode={null} />);
+      const json = view.toJSON() as any;
+      expect(json.props.lineDashPattern).toEqual([8, 6]);
+    });
+  });
+
+  describe("all modes comparison", () => {
+    const modes: {
+      mode: TravelMode;
+      color: string;
+      hasDash: boolean;
+      dashPattern?: number[];
+    }[] = [
+      {
+        mode: TRAVEL_MODE.WALK,
+        color: "#40509F",
+        hasDash: true,
+        dashPattern: [8, 6],
+      },
+      {
+        mode: TRAVEL_MODE.BICYCLE,
+        color: "#FF8C00",
+        hasDash: true,
+        dashPattern: [12, 6],
+      },
+      { mode: TRAVEL_MODE.SHUTTLE, color: "#9C2D2D", hasDash: false },
+      { mode: TRAVEL_MODE.TRANSIT, color: "#1E90FF", hasDash: false },
+      { mode: TRAVEL_MODE.DRIVE, color: "#40509F", hasDash: false },
+    ];
+
+    modes.forEach(({ mode, color, hasDash, dashPattern }) => {
+      it(`applies correct styling for ${mode}`, () => {
+        const route = makeRoute();
+        const view = render(<RoutePolyline route={route} travelMode={mode} />);
+        const json = view.toJSON() as any;
+        expect(json.props.strokeColor).toBe(color);
+        if (hasDash) {
+          expect(json.props.lineDashPattern).toEqual(dashPattern);
+        } else {
+          expect(json.props.lineDashPattern).toBeUndefined();
+        }
+      });
+    });
+  });
+});

--- a/mobile/__tests__/fixtures.ts
+++ b/mobile/__tests__/fixtures.ts
@@ -70,6 +70,7 @@ export function makeStep(overrides: Partial<StepInfo> = {}): StepInfo {
       { latitude: 45.4973, longitude: -73.5789 },
       { latitude: 45.498, longitude: -73.5789 },
     ],
+    travelMode: "WALK", // Default travel mode
     ...overrides,
   };
 }

--- a/mobile/src/components/LocationScreen/GoogleMaps.tsx
+++ b/mobile/src/components/LocationScreen/GoogleMaps.tsx
@@ -105,6 +105,11 @@ export default function GoogleMaps({
     animateToBuilding,
   } = useMapCamera(mapRef, location, state.route, state.panel);
 
+  const showRoutePolyline =
+    state.panel === "directions" ||
+    state.panel === "steps" ||
+    state.panel === "room-info";
+
   // ── Handle deep-link from Calendar (or other screens) ──
   useEffect(() => {
     if (!params.directionsTo || buildings.length === 0) return;
@@ -203,7 +208,9 @@ export default function GoogleMaps({
           onDirectionPress={onDirectionPress}
         />
 
-        <RoutePolyline route={state.route} travelMode={state.travelMode} />
+        {showRoutePolyline && (
+          <RoutePolyline route={state.route} travelMode={state.travelMode} />
+        )}
 
         {location && (
           <UserLocationMarker

--- a/mobile/src/components/LocationScreen/IndoorFloorView.tsx
+++ b/mobile/src/components/LocationScreen/IndoorFloorView.tsx
@@ -6,8 +6,8 @@ import {
   Pressable,
   ScrollView,
   Text,
-  View,
   TouchableOpacity,
+  View,
 } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 
@@ -17,7 +17,7 @@ import Animated, {
 } from "react-native-reanimated";
 
 import { SafeAreaView } from "react-native-safe-area-context";
-import Svg, { SvgUri, Polyline, Path } from "react-native-svg";
+import Svg, { Path, Polyline, SvgUri } from "react-native-svg";
 import { API_CONFIG, COLORS } from "../../constants";
 import {
   floorPlanAssetReducer,
@@ -27,9 +27,10 @@ import {
 } from "../../reducers/indoorFloorViewReducer";
 import { getIndoorPoisForBuilding } from "../../services/IndoorPoiService";
 import { Building } from "../../types/Building";
+import { RouteInfo } from "../../types/Directions";
 import { IndoorPoiCategory } from "../../types/IndoorPointOfInterest";
 import { IndoorRoom } from "../../types/IndoorRoom";
-import { RouteInfo } from "../../types/Directions";
+import { getFloorLabel } from "../../utils/indoorFloorUtils";
 import StepsPanel from "./StepsPanel";
 
 const BUILDING_NAMES: Record<string, string> = {
@@ -52,12 +53,6 @@ const RASTER_PLAN_FILES: Record<string, Record<number, string>> = {
   MB: { 1: "mb_1.png", 2: "mb_s2.png" },
   VL: { 1: "vl_1.png", 2: "vl_2.png" },
 };
-
-export function getFloorLabel(buildingId: string, floor: number): string {
-  if (buildingId === "MB" && floor === 2) return "S2";
-  if (buildingId === "MB" && floor === 1) return "1";
-  return `${floor}F`;
-}
 
 function sortFloorsForDisplay(buildingId: string, floors: number[]): number[] {
   if (buildingId === "MB") {

--- a/mobile/src/components/LocationScreen/RoutePolyline.tsx
+++ b/mobile/src/components/LocationScreen/RoutePolyline.tsx
@@ -1,6 +1,11 @@
 import { Polyline } from "react-native-maps";
 import { COLORS } from "../../constants";
-import { RouteInfo, TRAVEL_MODE, TravelMode } from "../../types/Directions";
+import {
+  RouteInfo,
+  StepInfo,
+  TRAVEL_MODE,
+  TravelMode,
+} from "../../types/Directions";
 
 interface RoutePolylineProps {
   readonly route: RouteInfo | null;
@@ -8,28 +13,131 @@ interface RoutePolylineProps {
 }
 
 /**
- * Returns the stroke color for a given travel mode.
+ * Determines the color for a step based on vehicle type or travel mode.
  */
-function getPolylineColor(travelMode: TravelMode | null): string {
+function getStepColor(step: StepInfo): string {
+  // If it's a transit step with vehicle details, color by vehicle type
+  if (step.transitDetails) {
+    const vehicleType = step.transitDetails.vehicleType?.toUpperCase();
+    switch (vehicleType) {
+      case "SUBWAY":
+      case "RAIL":
+        return "#FF6B35"; // Metro/Rail: Orange-red
+      case "BUS":
+        return "#1E90FF"; // Bus: Light blue
+      case "TROLLEYBUS":
+        return "#4169E1"; // Trolleybus: Royal blue
+      default:
+        return "#1E90FF"; // Default transit: Light blue
+    }
+  }
+
+  // Check travel mode for non-transit steps
+  if (step.travelMode) {
+    const mode = step.travelMode.toUpperCase();
+    switch (mode) {
+      case "BICYCLE":
+        return "#FF8C00"; // Cycling: Orange
+      case "DRIVE":
+        return "#40509F"; // Driving: Dark blue
+      case "WALK":
+      default:
+        return "#40509F"; // Walking: Dark blue
+    }
+  }
+
+  // Default: Dark blue for walking
+  return "#40509F";
+}
+
+/**
+ * Determines the line dash pattern for a step.
+ */
+function getStepLineDashPattern(step: StepInfo): number[] | undefined {
+  // If it's a transit step, use solid line
+  if (step.transitDetails) {
+    return undefined;
+  }
+
+  // Check travel mode for non-transit steps
+  if (step.travelMode) {
+    const mode = step.travelMode.toUpperCase();
+    switch (mode) {
+      case "BICYCLE":
+        return [12, 6]; // Cycling: Dashed line
+      case "WALK":
+        return [8, 6]; // Walking: Dotted line
+      case "DRIVE":
+      default:
+        return undefined; // Driving: Solid line
+    }
+  }
+
+  // Default: Dotted line for walking
+  return [8, 6];
+}
+
+/**
+ * Renders the navigation route polyline on the map with separate segments
+ * for each step, colored by vehicle type or travel mode.
+ */
+export default function RoutePolyline({
+  route,
+  travelMode,
+}: Readonly<RoutePolylineProps>) {
+  if (!route || route.coordinates.length < 2) return null;
+
+  // If there are no steps, render the entire route as one polyline
+  if (!route.steps || route.steps.length === 0) {
+    return (
+      <Polyline
+        coordinates={route.coordinates}
+        strokeColor={getDefaultPolylineColor(travelMode)}
+        strokeWidth={5}
+        lineDashPattern={getDefaultLineDashPattern(travelMode)}
+      />
+    );
+  }
+
+  // For each step, render a separate polyline segment
+  return (
+    <>
+      {route.steps.map((step, index) => (
+        <Polyline
+          key={`route-step-${index}`}
+          coordinates={step.coordinates}
+          strokeColor={getStepColor(step)}
+          strokeWidth={5}
+          lineDashPattern={getStepLineDashPattern(step)}
+        />
+      ))}
+    </>
+  );
+}
+
+/**
+ * Default color when no step-level coloring is available.
+ */
+function getDefaultPolylineColor(travelMode: TravelMode | null): string {
   switch (travelMode) {
     case TRAVEL_MODE.SHUTTLE:
       return COLORS.concordiaMaroon; // Concordia red
-    case TRAVEL_MODE.TRANSIT:
-      return "#1E90FF"; // Light blue
     case TRAVEL_MODE.BICYCLE:
-      return "#FF8C00"; // Orange
+      return "#FF8C00"; // Orange for cycling
     case TRAVEL_MODE.DRIVE:
-      return COLORS.mapPolylineWalk; // Dark blue
+      return COLORS.mapPolylineWalk; // Dark blue for driving
+    case TRAVEL_MODE.TRANSIT:
+      return "#1E90FF"; // Light blue for transit
     case TRAVEL_MODE.WALK:
     default:
-      return COLORS.mapPolylineWalk; // Dark blue
+      return COLORS.mapPolylineWalk; // Dark blue for walking
   }
 }
 
 /**
- * Returns the line dash pattern for a given travel mode.
+ * Default line dash pattern when no step-level styling is available.
  */
-function getLineDashPattern(
+function getDefaultLineDashPattern(
   travelMode: TravelMode | null,
 ): number[] | undefined {
   switch (travelMode) {
@@ -42,25 +150,6 @@ function getLineDashPattern(
     case TRAVEL_MODE.DRIVE:
       return undefined; // Solid line
     default:
-      return [8, 6]; // Default to dotted line (same as walking)
+      return [8, 6]; // Default to dotted line
   }
-}
-
-/**
- * Renders the navigation route polyline on the map.
- */
-export default function RoutePolyline({
-  route,
-  travelMode,
-}: Readonly<RoutePolylineProps>) {
-  if (!route?.coordinates || route.coordinates.length < 2) return null;
-
-  return (
-    <Polyline
-      coordinates={route.coordinates}
-      strokeColor={getPolylineColor(travelMode)}
-      strokeWidth={5}
-      lineDashPattern={getLineDashPattern(travelMode)}
-    />
-  );
 }

--- a/mobile/src/components/LocationScreen/RoutePolyline.tsx
+++ b/mobile/src/components/LocationScreen/RoutePolyline.tsx
@@ -1,80 +1,14 @@
 import { Polyline } from "react-native-maps";
 import { COLORS } from "../../constants";
+import { RouteInfo, TRAVEL_MODE, TravelMode } from "../../types/Directions";
 import {
-  RouteInfo,
-  StepInfo,
-  TRAVEL_MODE,
-  TravelMode,
-} from "../../types/Directions";
+  getStepColor,
+  getStepLineDashPattern,
+} from "../../utils/pathTypeUtils";
 
 interface RoutePolylineProps {
   readonly route: RouteInfo | null;
   readonly travelMode: TravelMode | null;
-}
-
-/**
- * Determines the color for a step based on vehicle type or travel mode.
- */
-function getStepColor(step: StepInfo): string {
-  // If it's a transit step with vehicle details, color by vehicle type
-  if (step.transitDetails) {
-    const vehicleType = step.transitDetails.vehicleType?.toUpperCase();
-    switch (vehicleType) {
-      case "SUBWAY":
-      case "RAIL":
-        return "#FF6B35"; // Metro/Rail: Orange-red
-      case "BUS":
-        return "#1E90FF"; // Bus: Light blue
-      case "TROLLEYBUS":
-        return "#4169E1"; // Trolleybus: Royal blue
-      default:
-        return "#1E90FF"; // Default transit: Light blue
-    }
-  }
-
-  // Check travel mode for non-transit steps
-  if (step.travelMode) {
-    const mode = step.travelMode.toUpperCase();
-    switch (mode) {
-      case "BICYCLE":
-        return "#FF8C00"; // Cycling: Orange
-      case "DRIVE":
-        return "#40509F"; // Driving: Dark blue
-      case "WALK":
-      default:
-        return "#40509F"; // Walking: Dark blue
-    }
-  }
-
-  // Default: Dark blue for walking
-  return "#40509F";
-}
-
-/**
- * Determines the line dash pattern for a step.
- */
-function getStepLineDashPattern(step: StepInfo): number[] | undefined {
-  // If it's a transit step, use solid line
-  if (step.transitDetails) {
-    return undefined;
-  }
-
-  // Check travel mode for non-transit steps
-  if (step.travelMode) {
-    const mode = step.travelMode.toUpperCase();
-    switch (mode) {
-      case "BICYCLE":
-        return [12, 6]; // Cycling: Dashed line
-      case "WALK":
-        return [8, 6]; // Walking: Dotted line
-      case "DRIVE":
-      default:
-        return undefined; // Driving: Solid line
-    }
-  }
-
-  // Default: Dotted line for walking
-  return [8, 6];
 }
 
 /**

--- a/mobile/src/components/LocationScreen/RoutePolyline.tsx
+++ b/mobile/src/components/LocationScreen/RoutePolyline.tsx
@@ -8,6 +8,45 @@ interface RoutePolylineProps {
 }
 
 /**
+ * Returns the stroke color for a given travel mode.
+ */
+function getPolylineColor(travelMode: TravelMode | null): string {
+  switch (travelMode) {
+    case TRAVEL_MODE.SHUTTLE:
+      return COLORS.concordiaMaroon; // Concordia red
+    case TRAVEL_MODE.TRANSIT:
+      return "#1E90FF"; // Light blue
+    case TRAVEL_MODE.BICYCLE:
+      return "#FF8C00"; // Orange
+    case TRAVEL_MODE.DRIVE:
+      return COLORS.mapPolylineWalk; // Dark blue
+    case TRAVEL_MODE.WALK:
+    default:
+      return COLORS.mapPolylineWalk; // Dark blue
+  }
+}
+
+/**
+ * Returns the line dash pattern for a given travel mode.
+ */
+function getLineDashPattern(
+  travelMode: TravelMode | null,
+): number[] | undefined {
+  switch (travelMode) {
+    case TRAVEL_MODE.WALK:
+      return [8, 6]; // Dotted line
+    case TRAVEL_MODE.BICYCLE:
+      return [12, 6]; // Dashed line
+    case TRAVEL_MODE.SHUTTLE:
+    case TRAVEL_MODE.TRANSIT:
+    case TRAVEL_MODE.DRIVE:
+      return undefined; // Solid line
+    default:
+      return [8, 6]; // Default to dotted line (same as walking)
+  }
+}
+
+/**
  * Renders the navigation route polyline on the map.
  */
 export default function RoutePolyline({
@@ -19,14 +58,9 @@ export default function RoutePolyline({
   return (
     <Polyline
       coordinates={route.coordinates}
-      strokeColor={
-        travelMode === TRAVEL_MODE.SHUTTLE
-          ? COLORS.concordiaMaroon
-          : COLORS.mapPolylineWalk
-      }
+      strokeColor={getPolylineColor(travelMode)}
       strokeWidth={5}
-      lineDashPattern={travelMode === TRAVEL_MODE.WALK ? [8, 6] : undefined}
-      zIndex={100}
+      lineDashPattern={getLineDashPattern(travelMode)}
     />
   );
 }

--- a/mobile/src/components/LocationScreen/StepsPanel.tsx
+++ b/mobile/src/components/LocationScreen/StepsPanel.tsx
@@ -21,9 +21,8 @@ import {
   formatDistance,
   formatDuration,
 } from "../../utils/formatHelper";
+import { getFloorLabel } from "../../utils/indoorFloorUtils";
 import TransitBadge from "./TransitBadge";
-
-import { getFloorLabel } from "./IndoorFloorView";
 
 interface StepsPanelProps {
   readonly building: Building;

--- a/mobile/src/constants/index.ts
+++ b/mobile/src/constants/index.ts
@@ -17,6 +17,11 @@ export const COLORS = {
   buildingFill: "rgba(156, 45, 45, 0.3)",
   groundsFill: "rgba(134, 134, 5, 0.3)",
   mapPolylineWalk: "#40509F",
+  mapPolylineBicycle: "#FF8C00",
+  mapPolylineDrive: "#40509F",
+  mapPolylineRail: "#FF6B35",
+  mapPolylineBus: "#1E90FF",
+  mapPolylineTrolleybus: "#4169E1",
 };
 
 export const METRO_ACCESS_BUILDINGS = ["H", "EV", "MB", "LB"];

--- a/mobile/src/services/DirectionsService.ts
+++ b/mobile/src/services/DirectionsService.ts
@@ -91,6 +91,7 @@ function parseRoute(data: DirectionsResponse): RouteInfo | null {
         coordinates: step.polyline?.encodedPolyline
           ? decodePolyline(step.polyline.encodedPolyline)
           : [],
+        travelMode: step.travelMode, // Preserve travel mode for step-level coloring
       };
 
       // Parse transit details if present

--- a/mobile/src/services/DirectionsService.ts
+++ b/mobile/src/services/DirectionsService.ts
@@ -91,7 +91,7 @@ function parseRoute(data: DirectionsResponse): RouteInfo | null {
         coordinates: step.polyline?.encodedPolyline
           ? decodePolyline(step.polyline.encodedPolyline)
           : [],
-        travelMode: step.travelMode, // Preserve travel mode for step-level coloring
+        travelMode: step.travelMode as TravelMode, // Preserve travel mode for step-level coloring
       };
 
       // Parse transit details if present

--- a/mobile/src/types/Directions.ts
+++ b/mobile/src/types/Directions.ts
@@ -95,6 +95,7 @@ export interface StepInfo {
   instruction: string;
   maneuver: string;
   coordinates: { latitude: number; longitude: number }[];
+  travelMode?: string; // e.g., "WALK", "BICYCLE", "TRANSIT"
   transitDetails?: TransitStepDetails;
   startFloor?: number;
   endFloor?: number;

--- a/mobile/src/types/Directions.ts
+++ b/mobile/src/types/Directions.ts
@@ -95,7 +95,7 @@ export interface StepInfo {
   instruction: string;
   maneuver: string;
   coordinates: { latitude: number; longitude: number }[];
-  travelMode?: string; // e.g., "WALK", "BICYCLE", "TRANSIT"
+  travelMode?: TravelMode; // e.g., TRAVEL_MODE.WALK, TRAVEL_MODE.BICYCLE, TRAVEL_MODE.TRANSIT
   transitDetails?: TransitStepDetails;
   startFloor?: number;
   endFloor?: number;

--- a/mobile/src/utils/indoorFloorUtils.ts
+++ b/mobile/src/utils/indoorFloorUtils.ts
@@ -1,0 +1,5 @@
+export function getFloorLabel(buildingId: string, floor: number): string {
+  if (buildingId === "MB" && floor === 2) return "S2";
+  if (buildingId === "MB" && floor === 1) return "1";
+  return `${floor}F`;
+}

--- a/mobile/src/utils/pathTypeUtils.ts
+++ b/mobile/src/utils/pathTypeUtils.ts
@@ -1,0 +1,66 @@
+import { StepInfo } from "../types/Directions";
+import { COLORS } from "../constants/index";
+/**
+ * Determines the color for a step based on vehicle type or travel mode.
+ */
+export function getStepColor(step: StepInfo): string {
+  // If it's a transit step with vehicle details, color by vehicle type
+  if (step.transitDetails) {
+    const vehicleType = step.transitDetails.vehicleType?.toUpperCase();
+    switch (vehicleType) {
+      case "SUBWAY":
+      case "RAIL":
+        return COLORS.mapPolylineRail; // Metro/Rail: Orange-red
+      case "BUS":
+        return COLORS.mapPolylineBus; // Bus: Light blue
+      case "TROLLEYBUS":
+        return COLORS.mapPolylineTrolleybus; // Trolleybus: Royal blue
+      default:
+        return COLORS.mapPolylineBus; // Default transit: Light blue
+    }
+  }
+
+  // Check travel mode for non-transit steps
+  if (step.travelMode) {
+    const mode = step.travelMode.toUpperCase();
+    switch (mode) {
+      case "BICYCLE":
+        return COLORS.mapPolylineBicycle; // Cycling: Orange
+      case "DRIVE":
+        return COLORS.mapPolylineDrive; // Driving: Dark blue
+      case "WALK":
+      default:
+        return COLORS.mapPolylineWalk; // Walking: Dark blue
+    }
+  }
+
+  // Default: Dark blue for walking
+  return COLORS.mapPolylineWalk;
+}
+
+/**
+ * Determines the line dash pattern for a step.
+ */
+export function getStepLineDashPattern(step: StepInfo): number[] | undefined {
+  // If it's a transit step, use solid line
+  if (step.transitDetails) {
+    return undefined;
+  }
+
+  // Check travel mode for non-transit steps
+  if (step.travelMode) {
+    const mode = step.travelMode.toUpperCase();
+    switch (mode) {
+      case "BICYCLE":
+        return [12, 6]; // Cycling: Dashed line
+      case "WALK":
+        return [8, 6]; // Walking: Dotted line
+      case "DRIVE":
+      default:
+        return undefined; // Driving: Solid line
+    }
+  }
+
+  // Default: Dotted line for walking
+  return [8, 6];
+}


### PR DESCRIPTION

<img width="1161" height="1025" alt="image" src="https://github.com/user-attachments/assets/c1dd7a2e-af0a-420c-b09e-a9743fd164a9" />
<img width="1012" height="666" alt="image" src="https://github.com/user-attachments/assets/c5944452-26c0-44cc-a25f-56df6472af16" />
<img width="1284" height="1230" alt="image" src="https://github.com/user-attachments/assets/1469ceee-2811-4508-bb7c-44e563f57475" />
<img width="1258" height="1197" alt="image" src="https://github.com/user-attachments/assets/27c8350e-5396-406b-b911-f3882d879dde" />


This pull request adds comprehensive unit tests for the `RoutePolyline` component and refactors its color and dash pattern logic for maintainability and clarity. The most important changes are grouped below:

**Testing improvements:**

* Added a new test suite `RoutePolyline-test.tsx` that thoroughly tests rendering behavior, color, and dash pattern for all travel modes, including edge cases like null routes and null travel modes.

**Code refactoring and maintainability:**

* Extracted logic for determining polyline color into a new helper function `getPolylineColor`, centralizing the mapping from travel mode to color.
* Extracted logic for determining dash patterns into a new helper function `getLineDashPattern`, centralizing the mapping from travel mode to dash style.
* Updated the `RoutePolyline` component to use the new helper functions for `strokeColor` and `lineDashPattern` props, improving readability and maintainability.