### PR TITLE
Improve building marker callout copy

### DIFF
--- a/mobile/__tests__/components/BuildingMarker-test.tsx
+++ b/mobile/__tests__/components/BuildingMarker-test.tsx
@@ -94,17 +94,7 @@ test("returns null when both coordinates are missing", () => {
   expect(toJSON()).toBeNull();
 });
 
-test("displays building code as title", () => {
-  const building = createBuilding({ buildingCode: "EV" });
-
-  const { toJSON } = render(<BuildingMarker building={building} />);
-  const tree = toJSON();
-
-  expect(tree).toBeTruthy();
-  expect(JSON.stringify(tree)).toContain("EV");
-});
-
-test("displays building name as description", () => {
+test("displays building name as the callout title", () => {
   const building = createBuilding({ buildingName: "Engineering Building" });
 
   const { toJSON } = render(<BuildingMarker building={building} />);
@@ -112,6 +102,16 @@ test("displays building name as description", () => {
 
   expect(tree).toBeTruthy();
   expect(JSON.stringify(tree)).toContain("Engineering Building");
+});
+
+test("displays actionable callout copy in the description", () => {
+  const building = createBuilding({ buildingCode: "EV" });
+
+  const { toJSON } = render(<BuildingMarker building={building} />);
+  const tree = toJSON();
+
+  expect(tree).toBeTruthy();
+  expect(JSON.stringify(tree)).toContain("EV - Details");
 });
 
 test("renders highlighted marker when isCurrentBuilding is true", () => {

--- a/mobile/__tests__/components/BuildingMarker-test.tsx
+++ b/mobile/__tests__/components/BuildingMarker-test.tsx
@@ -111,7 +111,7 @@ test("displays actionable callout copy in the description", () => {
   const tree = toJSON();
 
   expect(tree).toBeTruthy();
-  expect(JSON.stringify(tree)).toContain("EV - Details");
+  expect(JSON.stringify(tree)).toContain("EV - Tap for Details");
 });
 
 test("renders highlighted marker when isCurrentBuilding is true", () => {

--- a/mobile/src/components/LocationScreen/BuildingMarker.tsx
+++ b/mobile/src/components/LocationScreen/BuildingMarker.tsx
@@ -59,8 +59,8 @@ export default function BuildingMarker({
         latitude: building.latitude,
         longitude: building.longitude,
       }}
-      title={building.buildingCode}
-      description={building.buildingName}
+      title={building.buildingName}
+      description={`${building.buildingCode} - Tap for Details`}
       anchor={{ x: 0.5, y: 1 }}
       onPress={onSelect}
       onCalloutPress={onDirectionPress}


### PR DESCRIPTION
Adds Tap for Details to the map building popup so users can more clearly tell it’s clickable